### PR TITLE
harden backend by never returning owner id

### DIFF
--- a/backend/src/httpHandler.test.ts
+++ b/backend/src/httpHandler.test.ts
@@ -15,7 +15,11 @@ import { downloadEncryptedImage } from "./utils/uploaderDownloader";
 import { deleteImageFromBucket } from "./utils/s3";
 import { DeleteObjectCommandOutput } from "@aws-sdk/client-s3";
 import { prismaMock } from "../tests/helpers/mockPrisma";
-import { buildFullDocument } from "../tests/helpers/documentHelpers";
+import {
+  buildFullDocument,
+  buildCreatedDocument,
+  buildListedDocument,
+} from "../tests/helpers/documentHelpers";
 import { buildFullExampleImage } from "../tests/helpers/imageHelpers";
 
 vi.mock("stream/promises");
@@ -55,32 +59,29 @@ describe("handleHealthRequest", () => {
 });
 
 describe("handleCreateDocumentRequest", () => {
-  it("creates a document without owner", async () => {
-    const doc = buildFullDocument({ ownerExternalId: null });
-    prismaMock.document.create.mockResolvedValue(doc);
+  it("does not include ownerExternalId in the response body", async () => {
+    prismaMock.document.create.mockResolvedValue(
+      buildCreatedDocument() as never,
+    );
 
     const response = mock<ServerResponse<IncomingMessage>>();
-    await handleCreateDocumentRequest(response, prismaMock, null);
+    await handleCreateDocumentRequest(response, prismaMock, "owner-123");
 
-    const result = JSON.parse(
-      response.end.mock.calls[0][0] as string,
-    ) as Document;
-    expect(result.id).toBeDefined();
-    expect(result.ownerExternalId).toBeNull();
+    const body = response.end.mock.calls[0][0] as string;
+    expect(body).not.toContain("ownerExternalId");
   });
 
-  it("creates a document with owner", async () => {
-    const doc = buildFullDocument({ ownerExternalId: "123" });
-    prismaMock.document.create.mockResolvedValue(doc);
+  it("returns the document produced by the model", async () => {
+    // The model omits ownerExternalId, so the mock returns the production
+    // shape; the handler serializes it verbatim (dates become ISO strings).
+    const created = buildCreatedDocument();
+    prismaMock.document.create.mockResolvedValue(created as never);
 
     const response = mock<ServerResponse<IncomingMessage>>();
-    await handleCreateDocumentRequest(response, prismaMock, "123");
+    await handleCreateDocumentRequest(response, prismaMock, "owner-123");
 
-    const result = JSON.parse(
-      response.end.mock.calls[0][0] as string,
-    ) as Document;
-    expect(result.id).toBeDefined();
-    expect(result.ownerExternalId).toEqual("123");
+    const body = response.end.mock.calls[0][0] as string;
+    expect(JSON.parse(body)).toEqual(JSON.parse(JSON.stringify(created)));
   });
 });
 
@@ -96,18 +97,29 @@ describe("handleGetOwnDocumentsRequest", () => {
     expect(prismaMock.document.findMany).not.toHaveBeenCalled();
   });
 
-  it("returns list when ownerId is provided", async () => {
-    const doc = buildFullDocument({ ownerExternalId: "owner-234" });
-    prismaMock.document.findMany.mockResolvedValue([doc]);
+  it("does not include ownerExternalId in any returned document", async () => {
+    const doc = buildListedDocument({ ownerExternalId: "owner-234" });
+    prismaMock.document.findMany.mockResolvedValue([doc] as never);
 
     const response = mock<ServerResponse<IncomingMessage>>();
     await handleGetOwnDocumentsRequest(response, prismaMock, "owner-234");
 
-    const result = JSON.parse(
-      response.end.mock.calls[0][0] as string,
-    ) as Document[];
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toEqual(doc.id);
+    const body = response.end.mock.calls[0][0] as string;
+    expect(body).not.toContain("ownerExternalId");
+  });
+
+  it("returns the owner's documents produced by the model", async () => {
+    // The model omits ownerExternalId and data, so the mock returns the
+    // production shape (id, modificationSecret, timestamps); the handler
+    // serializes it verbatim (dates become ISO strings).
+    const doc = buildListedDocument({ ownerExternalId: "owner-234" });
+    prismaMock.document.findMany.mockResolvedValue([doc] as never);
+
+    const response = mock<ServerResponse<IncomingMessage>>();
+    await handleGetOwnDocumentsRequest(response, prismaMock, "owner-234");
+
+    const body = response.end.mock.calls[0][0] as string;
+    expect(JSON.parse(body)).toEqual(JSON.parse(JSON.stringify([doc])));
   });
 });
 

--- a/backend/src/httpHandler.ts
+++ b/backend/src/httpHandler.ts
@@ -53,7 +53,7 @@ export const handleGetOwnDocumentsRequest = async (
     response.end(JSON.stringify([]));
     return;
   }
-  console.debug(`Fetching documents for ownerExternalId=${personId}`);
+  console.debug(`Fetching documents for authenticated owner`);
   const documents = await getDocumentsByOwner(prisma, personId).catch(
     (error: Error) => {
       console.error(error);

--- a/backend/src/model/document.test.ts
+++ b/backend/src/model/document.test.ts
@@ -9,7 +9,11 @@ import {
   createDocument,
   getDocumentsByOwner,
 } from "./document";
-import { buildFullDocument } from "../../tests/helpers/documentHelpers";
+import {
+  buildFullDocument,
+  buildCreatedDocument,
+  buildListedDocument,
+} from "../../tests/helpers/documentHelpers";
 import { buildFullExampleImage } from "../../tests/helpers/imageHelpers";
 import { deleteImage } from "./image";
 import { deleteImageFromBucket } from "../utils/s3";
@@ -40,6 +44,7 @@ describe("deleteOldDocuments", () => {
     });
     expect(prismaMock.document.delete).toHaveBeenCalledWith({
       where: { id: oldDoc.id },
+      omit: { ownerExternalId: true },
     });
   });
 
@@ -81,6 +86,7 @@ describe("deleteDocument", () => {
     expect(result).toBeTruthy();
     expect(prismaMock.document.delete).toHaveBeenCalledWith({
       where: { id: doc.id },
+      omit: { ownerExternalId: true },
     });
   });
 
@@ -150,6 +156,7 @@ describe("updateLastAccessedAt", () => {
     expect(prismaMock.document.update).toHaveBeenCalledWith({
       where: { id: doc.id },
       data: { lastAccessedAt: expect.any(Date) as Date },
+      omit: { ownerExternalId: true },
     });
   });
 
@@ -257,6 +264,7 @@ describe("updateDocument", () => {
         updatedAt: expect.any(Date) as Date,
         lastAccessedAt: expect.any(Date) as Date,
       },
+      omit: { ownerExternalId: true },
     });
   });
 
@@ -282,43 +290,75 @@ describe("updateDocument", () => {
 
 describe("document ownership", () => {
   describe("createDocument", () => {
-    it("assigns ownerExternalId when passed", async () => {
+    it("records the ownerExternalId insert value but omits it from the query result", async () => {
       const doc = buildFullDocument({ ownerExternalId: "owner-123" });
       prismaMock.document.create.mockResolvedValue(doc);
 
-      const result = await createDocument(prismaMock, "owner-123");
+      await createDocument(prismaMock, "owner-123");
 
-      expect(result.ownerExternalId).toBe("owner-123");
       expect(prismaMock.document.create).toHaveBeenCalledWith({
         data: { ownerExternalId: "owner-123" },
+        omit: { ownerExternalId: true },
       });
     });
 
-    it("sets ownerExternalId to null when null is passed", async () => {
+    it("records a null ownerExternalId when null is passed and still omits it", async () => {
       const doc = buildFullDocument({ ownerExternalId: null });
       prismaMock.document.create.mockResolvedValue(doc);
 
-      const result = await createDocument(prismaMock, null);
+      await createDocument(prismaMock, null);
 
-      expect(result.ownerExternalId).toBeNull();
+      expect(prismaMock.document.create).toHaveBeenCalledWith({
+        data: { ownerExternalId: null },
+        omit: { ownerExternalId: true },
+      });
+    });
+
+    it("returns the created document without the ownerExternalId field", async () => {
+      // Simulate Prisma honouring the `omit` clause (the mock cannot do this
+      // on its own); createDocument returns that production-shape row verbatim,
+      // so an exact match proves no ownerExternalId key is present.
+      const created = buildCreatedDocument();
+      prismaMock.document.create.mockResolvedValue(created as never);
+
+      const result = await createDocument(prismaMock, "owner-123");
+
+      expect(result).toEqual(created);
     });
   });
 
   describe("getDocumentsByOwner", () => {
-    it("returns only documents with matching ownerExternalId in the correct order", async () => {
+    it("scopes the query to the owner and omits ownerExternalId and data", async () => {
+      // The `where` clause is what isolates one owner's documents from
+      // another's, so asserting it covers ownership filtering (AC5).
       const ownerA = "owner-A";
-      const doc1 = buildFullDocument({ ownerExternalId: ownerA });
-      const doc2 = buildFullDocument({ ownerExternalId: ownerA });
+      prismaMock.document.findMany.mockResolvedValue([]);
 
-      prismaMock.document.findMany.mockResolvedValue([doc1, doc2]);
+      await getDocumentsByOwner(prismaMock, ownerA);
 
-      const docs = await getDocumentsByOwner(prismaMock, ownerA);
-
-      expect(docs.length).toBe(2);
       expect(prismaMock.document.findMany).toHaveBeenCalledWith({
         where: { ownerExternalId: ownerA },
         orderBy: { createdAt: "desc" },
+        omit: { ownerExternalId: true, data: true },
       });
+    });
+
+    it("returns the owner's documents without the ownerExternalId field", async () => {
+      // Simulate Prisma honouring the `omit` clause for owned documents; an
+      // exact match proves no element carries an ownerExternalId key.
+      const ownerADocs = [buildListedDocument(), buildListedDocument()];
+      prismaMock.document.findMany.mockResolvedValue(ownerADocs as never);
+
+      const docs = await getDocumentsByOwner(prismaMock, "owner-A");
+
+      expect(docs).toEqual(ownerADocs);
+    });
+
+    it("returns an empty list without querying when ownerExternalId is an empty string", async () => {
+      const docs = await getDocumentsByOwner(prismaMock, "");
+
+      expect(docs).toEqual([]);
+      expect(prismaMock.document.findMany).not.toHaveBeenCalled();
     });
 
     it("returns an empty list if owner has no documents", async () => {

--- a/backend/src/model/document.ts
+++ b/backend/src/model/document.ts
@@ -8,7 +8,10 @@ export const createDocument = async (
   prisma: PrismaClient,
   personId?: string | null,
 ) => {
-  return prisma.document.create({ data: { ownerExternalId: personId } });
+  return prisma.document.create({
+    data: { ownerExternalId: personId },
+    omit: { ownerExternalId: true },
+  });
 };
 
 export const fetchDocument = async (
@@ -43,6 +46,7 @@ export const getDocumentsByOwner = async (
     orderBy: {
       createdAt: "desc",
     },
+    omit: { ownerExternalId: true, data: true },
   });
 };
 
@@ -61,6 +65,7 @@ export const updateDocument = async (
         updatedAt: new Date(),
         lastAccessedAt: new Date(),
       },
+      omit: { ownerExternalId: true },
     });
 
     return true;
@@ -149,6 +154,7 @@ export const updateLastAccessedAt = async (
     await prisma.document.update({
       where: { id: documentName },
       data: { lastAccessedAt: new Date() },
+      omit: { ownerExternalId: true },
     });
   } catch {
     console.info(`Document ${documentName} does not exist yet`);
@@ -205,5 +211,6 @@ const deleteDocumentWithImages = async (
     where: {
       id: documentId,
     },
+    omit: { ownerExternalId: true },
   });
 };

--- a/backend/tests/helpers/documentHelpers.ts
+++ b/backend/tests/helpers/documentHelpers.ts
@@ -28,3 +28,24 @@ export const buildFullDocument = (
     ...overrides,
   };
 };
+
+// The shape POST /documents returns: ownerExternalId is stripped by the
+// model's `omit`, so it never reaches the client.
+export const buildCreatedDocument = (
+  overrides: Partial<Document> = {},
+): Omit<Document, "ownerExternalId"> => {
+  const doc: Partial<Document> = buildFullDocument(overrides);
+  delete doc.ownerExternalId;
+  return doc as Omit<Document, "ownerExternalId">;
+};
+
+// The shape each element of GET /documents returns: both ownerExternalId and
+// the heavy `data` blob are stripped by the model's `omit`.
+export const buildListedDocument = (
+  overrides: Partial<Document> = {},
+): Omit<Document, "ownerExternalId" | "data"> => {
+  const doc: Partial<Document> = buildFullDocument(overrides);
+  delete doc.ownerExternalId;
+  delete doc.data;
+  return doc as Omit<Document, "ownerExternalId" | "data">;
+};


### PR DESCRIPTION
- Never return owner id to frontend users, even though the admin id is provided